### PR TITLE
 hotfix/2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waynestate/wsuheader",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Wayne State University Header",
     "scripts": {
         "build": "./build.sh"


### PR DESCRIPTION
Bump the version to allow publishing on NPMJS

Due to NPMJS repo not allowing me to publish 2.0.2, bump up to 2.0.3 to be the latest version on NPMJS

```
npm ERR! publish Failed PUT 403
npm ERR! code E403
npm ERR! You cannot publish over the previously published version 2.0.2. : @waynestate/wsuheader
```

version bump to 2.0.3