### PR TITLE
hotfix/2.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waynestate/wsuheader",
-    "version": "2.0.11",
+    "version": "2.0.12",
     "description": "Wayne State University Header",
     "scripts": {
         "build": "webpack --optimize-minimize && cp src/header.html dist/header.html && cat src/demo-start.html src/header.html src/demo-end.html > demo/index.html"

--- a/src/header.scss
+++ b/src/header.scss
@@ -43,6 +43,15 @@
         position: relative;
     }
 
+    a {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        max-width: 605px;
+    }
+
     // Fit svg to h1 container
     svg {
         position: absolute;
@@ -309,15 +318,6 @@
         h1 {
             height: 65px;
             padding: 0;
-        }
-
-        a {
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            max-width: 605px;
         }
 
         svg {


### PR DESCRIPTION
Keep the same positioning across all breakpoints so the focus ring surrounds the whole SVG all the time. The issue is there wasn't any width/position being set on smaller screens so the element was acting as 0 width and the focus ring would go away.

No visual change to the actual header in this PR.